### PR TITLE
UNOMI-279: Implement createOrUpdateSegment mutation

### DIFF
--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/CreateOrUpdateSegmentCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/CreateOrUpdateSegmentCommand.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.graphql.commands;
+
+import com.google.common.base.Strings;
+import graphql.schema.DataFetchingEnvironment;
+import org.apache.unomi.api.Metadata;
+import org.apache.unomi.api.conditions.Condition;
+import org.apache.unomi.api.segments.Segment;
+import org.apache.unomi.api.services.SegmentService;
+import org.apache.unomi.graphql.services.ServiceManager;
+import org.apache.unomi.graphql.types.input.CDPProfileFilterInput;
+import org.apache.unomi.graphql.types.input.CDPSegmentInput;
+import org.apache.unomi.graphql.types.output.CDPSegment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CreateOrUpdateSegmentCommand extends BaseCommand<CDPSegment> {
+
+    private final CDPSegmentInput segmentInput;
+
+    private final DataFetchingEnvironment environment;
+
+    private CreateOrUpdateSegmentCommand(Builder builder) {
+        super(builder);
+
+        this.segmentInput = builder.segmentInput;
+        this.environment = builder.environment;
+    }
+
+    @Override
+    public CDPSegment execute() {
+        final ServiceManager serviceManager = environment.getContext();
+
+        final SegmentService segmentService = serviceManager.getSegmentService();
+
+        final String segmentId = Strings.isNullOrEmpty(segmentInput.getId())
+                ? segmentInput.getName()
+                : segmentInput.getId();
+
+        Segment segment = segmentService.getSegmentDefinition(segmentId);
+
+        if (segment == null) {
+            segment = new Segment();
+
+            segment.setItemType(Segment.ITEM_TYPE);
+            segment.setMetadata(createMedata(segmentId));
+        } else {
+            if (segment.getMetadata() == null) {
+                segment.setMetadata(new Metadata());
+            }
+
+            segment.setItemId(segmentId);
+            segment.getMetadata().setId(segmentId);
+            segment.getMetadata().setName(segmentInput.getName());
+            segment.getMetadata().setScope(segmentInput.getView());
+        }
+
+        final Condition condition = createSegmentCondition();
+        segment.setCondition(condition);
+
+        segmentService.setSegmentDefinition(segment);
+
+        return new CDPSegment(segment);
+    }
+
+    private Metadata createMedata(final String segmentId) {
+        final Metadata metadata = new Metadata();
+
+        metadata.setId(segmentId);
+        metadata.setName(segmentInput.getName());
+        metadata.setScope(segmentInput.getView());
+
+        return metadata;
+    }
+
+    private List<Condition> createSubCondition() {
+        final CDPProfileFilterInput filterInput = segmentInput.getProfiles();
+
+        if (filterInput == null) {
+            return Collections.emptyList();
+        }
+
+        final List<Condition> conditions = new ArrayList<>();
+
+        if (filterInput.getSegments_contains() != null && !filterInput.getSegments_contains().isEmpty()) {
+            final Condition segmentsContainsCondition =
+                    createContainsCondition(filterInput.getSegments_contains(), "profileSegmentCondition", "segments");
+
+            conditions.add(segmentsContainsCondition);
+        }
+
+        if (filterInput.getProfileIDs_contains() != null && !filterInput.getProfileIDs_contains().isEmpty()) {
+            final Condition profileIDsContainsCondition =
+                    createContainsCondition(filterInput.getProfileIDs_contains(), "profilePropertyCondition", "itemId");
+
+            conditions.add(profileIDsContainsCondition);
+        }
+
+        if (filterInput.getLists_contains() != null && !filterInput.getLists_contains().isEmpty()) {
+            final Condition listsContainsCondition =
+                    createContainsCondition(filterInput.getLists_contains(), "profileUserListCondition", "lists");
+
+            conditions.add(listsContainsCondition);
+        }
+
+        return conditions;
+    }
+
+    private Condition createContainsCondition(List<String> values, String conditionId, String propertyName) {
+        final Condition condition = new Condition();
+
+        condition.setConditionType(serviceManager.getDefinitionsService().getConditionType("booleanCondition"));
+        condition.setParameter("operator", "or");
+
+        final List<Condition> subConditions = new ArrayList<>();
+
+        for (String value : values) {
+            final Condition subCondition = new Condition();
+
+            subCondition.setConditionType(serviceManager.getDefinitionsService().getConditionType(conditionId));
+            subCondition.setParameter("propertyName", propertyName);
+            subCondition.setParameter("comparisonOperator", "contains");
+            subCondition.setParameter("propertyValue", value);
+
+            subConditions.add(subCondition);
+        }
+        condition.setParameter("subConditions", subConditions);
+
+        return condition;
+    }
+
+
+    private Condition createSegmentCondition() {
+        final Condition condition = new Condition();
+
+        condition.setConditionType(serviceManager.getDefinitionsService().getConditionType("booleanCondition"));
+        condition.setParameter("operator", "and");
+
+        final List<Condition> subConditions = createSubCondition();
+        condition.setParameter("subConditions", subConditions);
+
+        return condition;
+    }
+
+    public static Builder create(final CDPSegmentInput segmentInput, final DataFetchingEnvironment environment) {
+        return new Builder(segmentInput, environment);
+    }
+
+    public static class Builder extends BaseCommand.Builder<Builder> {
+
+        private final CDPSegmentInput segmentInput;
+
+        private final DataFetchingEnvironment environment;
+
+        public Builder(CDPSegmentInput segmentInput, DataFetchingEnvironment environment) {
+            this.segmentInput = segmentInput;
+            this.environment = environment;
+        }
+
+        private void validate() {
+            if (segmentInput == null) {
+                throw new IllegalArgumentException();
+            }
+            if (Strings.isNullOrEmpty(segmentInput.getName())) {
+                throw new IllegalArgumentException();
+            }
+            if (Strings.isNullOrEmpty(segmentInput.getView())) {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        public CreateOrUpdateSegmentCommand build() {
+            validate();
+
+            return new CreateOrUpdateSegmentCommand(this);
+        }
+
+    }
+
+}

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/DeleteAllPersonalDataCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/DeleteAllPersonalDataCommand.java
@@ -18,7 +18,7 @@ package org.apache.unomi.graphql.commands;
 
 import com.google.common.base.Strings;
 import graphql.schema.DataFetchingEnvironment;
-import org.apache.unomi.api.Persona;
+import org.apache.unomi.api.Profile;
 import org.apache.unomi.graphql.services.ServiceManager;
 
 import java.util.Map;
@@ -40,17 +40,15 @@ public class DeleteAllPersonalDataCommand extends BaseCommand<Boolean> {
 
         final Map<String, Object> cdpProfileIdInput = environment.getArgument("profileID");
 
-        final String personaId = (String) cdpProfileIdInput.get("id");
+        final String profileId = (String) cdpProfileIdInput.get("id");
 
-        final Persona persona = serviceManager.getProfileService().loadPersona(personaId);
+        final Profile profile = serviceManager.getProfileService().load(profileId);
 
-        if (persona == null) {
-            throw new IllegalStateException(String.format("The persona with id \"%s\" not found", personaId));
+        if (profile == null) {
+            return false;
         }
 
-        serviceManager.getProfileService().delete(personaId, true);
-
-        return true;
+        return serviceManager.getPrivacyService().deleteProfileData(profileId);
     }
 
     public static Builder create(final DataFetchingEnvironment environment) {

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/schema/GraphQLSchemaUpdater.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/schema/GraphQLSchemaUpdater.java
@@ -45,6 +45,7 @@ import org.apache.unomi.graphql.providers.GraphQLTypesProvider;
 import org.apache.unomi.graphql.types.RootMutation;
 import org.apache.unomi.graphql.types.RootQuery;
 import org.apache.unomi.graphql.types.input.CDPEventInput;
+import org.apache.unomi.graphql.types.input.CDPProfilePropertiesFilterInput;
 import org.apache.unomi.graphql.types.input.CDPProfileUpdateEventInput;
 import org.apache.unomi.graphql.types.output.CDPProfile;
 import org.osgi.service.component.annotations.Activate;
@@ -63,7 +64,6 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Component(service = GraphQLSchemaUpdater.class)
@@ -213,20 +213,24 @@ public class GraphQLSchemaUpdater {
             return;
         }
 
-        try {
-            if (updateFuture != null) {
-                updateFuture.cancel(true);
-            }
+        final GraphQLSchema graphQLSchema = createGraphQLSchema();
 
-            updateFuture = executorService.scheduleWithFixedDelay(() -> {
-                final GraphQLSchema graphQLSchema = createGraphQLSchema();
+        this.graphQL = GraphQL.newGraphQL(graphQLSchema).build();
 
-                this.graphQL = GraphQL.newGraphQL(graphQLSchema).build();
-            }, 0, 60, TimeUnit.SECONDS); // TODO should be configurable
-        } catch (Exception e) {
-            executorService.shutdown();
-            throw e;
-        }
+//        try {
+//            if (updateFuture != null) {
+//                updateFuture.cancel(true);
+//            }
+//
+//            updateFuture = executorService.scheduleWithFixedDelay(() -> {
+//                final GraphQLSchema graphQLSchema = createGraphQLSchema();
+//
+//                this.graphQL = GraphQL.newGraphQL(graphQLSchema).build();
+//            }, 0, 60, TimeUnit.SECONDS); // TODO should be configurable
+//        } catch (Exception e) {
+//            executorService.shutdown();
+//            throw e;
+//        }
     }
 
     public GraphQL getGraphQL() {
@@ -321,6 +325,7 @@ public class GraphQLSchemaUpdater {
 
     private void setUpDynamicFields() {
         registerDynamicFields(graphQLAnnotations, "profiles", CDPProfile.TYPE_NAME, CDPProfile.class);
+        registerDynamicFields(graphQLAnnotations, "profiles", CDPProfilePropertiesFilterInput.TYPE_NAME, CDPProfilePropertiesFilterInput.class);
     }
 
     private void setUpQueries(final Map<String, GraphQLType> typeRegistry) {

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/services/ServiceManager.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/services/ServiceManager.java
@@ -18,6 +18,7 @@ package org.apache.unomi.graphql.services;
 
 import org.apache.unomi.api.services.DefinitionsService;
 import org.apache.unomi.api.services.EventService;
+import org.apache.unomi.api.services.PrivacyService;
 import org.apache.unomi.api.services.ProfileService;
 import org.apache.unomi.api.services.SegmentService;
 import org.apache.unomi.graphql.schema.GraphQLSchemaUpdater;
@@ -32,6 +33,7 @@ public class ServiceManager {
     private EventService eventService;
     private DefinitionsService definitionsService;
     private GraphQLSchemaUpdater graphQLSchemaUpdater;
+    private PrivacyService privacyService;
 
     @Reference
     public void setProfileService(ProfileService profileService) {
@@ -58,6 +60,11 @@ public class ServiceManager {
         this.graphQLSchemaUpdater = graphQLSchemaUpdater;
     }
 
+    @Reference
+    public void setPrivacyService(PrivacyService privacyService) {
+        this.privacyService = privacyService;
+    }
+
     public ProfileService getProfileService() {
         return profileService;
     }
@@ -76,6 +83,10 @@ public class ServiceManager {
 
     public GraphQLSchemaUpdater getGraphQLSchemaUpdater() {
         return graphQLSchemaUpdater;
+    }
+
+    public PrivacyService getPrivacyService() {
+        return privacyService;
     }
 
 }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/CDPMutation.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/CDPMutation.java
@@ -25,9 +25,12 @@ import org.apache.unomi.graphql.commands.DeleteAllPersonalDataCommand;
 import org.apache.unomi.graphql.commands.DeleteProfileCommand;
 import org.apache.unomi.graphql.commands.DeleteProfilePropertiesCommand;
 import org.apache.unomi.graphql.commands.ProcessEventsCommand;
+import org.apache.unomi.graphql.commands.CreateOrUpdateSegmentCommand;
 import org.apache.unomi.graphql.types.input.CDPEventInput;
 import org.apache.unomi.graphql.types.input.CDPProfileIDInput;
 import org.apache.unomi.graphql.types.input.CDPPropertyInput;
+import org.apache.unomi.graphql.types.input.CDPSegmentInput;
+import org.apache.unomi.graphql.types.output.CDPSegment;
 
 import java.util.List;
 
@@ -85,6 +88,17 @@ public class CDPMutation {
             final @GraphQLNonNull @GraphQLName("profileID") CDPProfileIDInput profileIDInput,
             final DataFetchingEnvironment environment) {
         return DeleteAllPersonalDataCommand.create(environment)
+                .setServiceManager(environment.getContext())
+                .build()
+                .execute();
+    }
+
+    @GraphQLField
+    public CDPSegment createOrUpdateSegment(
+            final @GraphQLName("segment") CDPSegmentInput segmentInput,
+            final DataFetchingEnvironment environment
+    ) {
+        return CreateOrUpdateSegmentCommand.create(segmentInput, environment)
                 .setServiceManager(environment.getContext())
                 .build()
                 .execute();

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPClientInput.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPClientInput.java
@@ -32,8 +32,8 @@ public class CDPClientInput {
     @GraphQLField
     private String title;
 
-    public CDPClientInput() {
-    }
+//    public CDPClientInput() {
+//    }
 
     public CDPClientInput(
             final @GraphQLID @GraphQLNonNull @GraphQLName("id") String id,

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPInterestFilterInput.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPInterestFilterInput.java
@@ -50,8 +50,8 @@ public class CDPInterestFilterInput {
     @GraphQLField
     private Float score_gte;
 
-    public CDPInterestFilterInput() {
-    }
+//    public CDPInterestFilterInput() {
+//    }
 
     public CDPInterestFilterInput(@GraphQLName("and") List<CDPInterestFilterInput> and,
                                   @GraphQLName("or") List<CDPInterestFilterInput> or,

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPProfileEventsFilterInput.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPProfileEventsFilterInput.java
@@ -44,8 +44,8 @@ public class CDPProfileEventsFilterInput {
     @GraphQLField
     private CDPEventFilterInput eventFilter;
 
-    public CDPProfileEventsFilterInput() {
-    }
+//    public CDPProfileEventsFilterInput() {
+//    }
 
     public CDPProfileEventsFilterInput(@GraphQLName("and") List<CDPProfileEventsFilterInput> and,
                                        @GraphQLName("or") List<CDPProfileEventsFilterInput> or,

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPProfileFilterInput.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPProfileFilterInput.java
@@ -46,8 +46,8 @@ public class CDPProfileFilterInput {
     @GraphQLField
     private CDPProfileEventsFilterInput events;
 
-    public CDPProfileFilterInput() {
-    }
+//    public CDPProfileFilterInput() {
+//    }
 
     public CDPProfileFilterInput(@GraphQLName("profileIDs_contains") List<String> profileIDs_contains,
                                  @GraphQLName("segments_contains") List<String> segments_contains,

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPProfilePropertiesFilterInput.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPProfilePropertiesFilterInput.java
@@ -23,8 +23,14 @@ import graphql.annotations.annotationTypes.GraphQLName;
 import java.util.ArrayList;
 import java.util.List;
 
-@GraphQLName("CDP_ProfilePropertiesFilterInput")
+import static org.apache.unomi.graphql.types.input.CDPProfilePropertiesFilterInput.TYPE_NAME_INTERNAL;
+
+@GraphQLName(TYPE_NAME_INTERNAL)
 public class CDPProfilePropertiesFilterInput {
+
+    public static final String TYPE_NAME_INTERNAL = "CDP_ProfilePropertiesFilter";
+
+    public static final String TYPE_NAME = TYPE_NAME_INTERNAL + "Input";
 
     @GraphQLField
     private List<CDPProfilePropertiesFilterInput> and = new ArrayList<>();
@@ -32,8 +38,8 @@ public class CDPProfilePropertiesFilterInput {
     @GraphQLField
     private List<CDPProfilePropertiesFilterInput> or = new ArrayList<>();
 
-    public CDPProfilePropertiesFilterInput() {
-    }
+//    public CDPProfilePropertiesFilterInput() {
+//    }
 
     public CDPProfilePropertiesFilterInput(@GraphQLName("and") List<CDPProfilePropertiesFilterInput> and,
                                            @GraphQLName("or") List<CDPProfilePropertiesFilterInput> or) {

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPSegmentInput.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/input/CDPSegmentInput.java
@@ -21,34 +21,50 @@ import graphql.annotations.annotationTypes.GraphQLID;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
 
-@GraphQLName("CDP_ProfileID")
-public class CDPProfileIDInput {
+@GraphQLName("CDP_Segment")
+public class CDPSegmentInput {
+
+    @GraphQLID
+    @GraphQLField
+    private String id;
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    private String id;
+    private String view;
 
     @GraphQLField
     @GraphQLNonNull
-    private CDPClientInput client;
+    private String name;
 
-//    public CDPProfileIDInput() {
-//    }
+    @GraphQLField
+    private CDPProfileFilterInput profiles;
 
-    public CDPProfileIDInput(
-            final @GraphQLID @GraphQLNonNull @GraphQLName("id") String id,
-            final @GraphQLNonNull @GraphQLName("client") CDPClientInput client) {
+    public CDPSegmentInput(
+            final @GraphQLID @GraphQLName("id") String id,
+            final @GraphQLID @GraphQLNonNull @GraphQLName("view") String view,
+            final @GraphQLNonNull @GraphQLName("name") String name,
+            final @GraphQLName("profiles") CDPProfileFilterInput profiles) {
         this.id = id;
-        this.client = client;
+        this.view = view;
+        this.name = name;
+        this.profiles = profiles;
     }
 
     public String getId() {
         return id;
     }
 
-    public CDPClientInput getClient() {
-        return client;
+    public String getView() {
+        return view;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public CDPProfileFilterInput getProfiles() {
+        return profiles;
     }
 
 }


### PR DESCRIPTION
Initial version of the `createOrUpdateSegment` mutation

- added simple mutation which creates a segment using id, name, view and profiles (condition),
- condition supports `segments_contains`, `profileIDs_contains` and `lists_contains`

this functionality will be extended a little bit later