### PR TITLE
UNOMI-278: Implement deleteSegment mutation

### DIFF
--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/BaseCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/BaseCommand.java
@@ -20,7 +20,7 @@ import org.apache.unomi.graphql.services.ServiceManager;
 
 public abstract class BaseCommand<T> {
 
-    final ServiceManager serviceManager;
+    protected final ServiceManager serviceManager;
 
     public abstract T execute();
 

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/CreateOrUpdateSegmentCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/CreateOrUpdateSegmentCommand.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.unomi.graphql.commands;
+package org.apache.unomi.graphql.commands.segments;
 
 import com.google.common.base.Strings;
 import graphql.schema.DataFetchingEnvironment;
@@ -22,6 +22,7 @@ import org.apache.unomi.api.Metadata;
 import org.apache.unomi.api.conditions.Condition;
 import org.apache.unomi.api.segments.Segment;
 import org.apache.unomi.api.services.SegmentService;
+import org.apache.unomi.graphql.commands.BaseCommand;
 import org.apache.unomi.graphql.services.ServiceManager;
 import org.apache.unomi.graphql.types.input.CDPProfileFilterInput;
 import org.apache.unomi.graphql.types.input.CDPSegmentInput;
@@ -100,8 +101,11 @@ public class CreateOrUpdateSegmentCommand extends BaseCommand<CDPSegment> {
         final List<Condition> conditions = new ArrayList<>();
 
         if (filterInput.getSegments_contains() != null && !filterInput.getSegments_contains().isEmpty()) {
-            final Condition segmentsContainsCondition =
-                    createContainsCondition(filterInput.getSegments_contains(), "profileSegmentCondition", "segments");
+            final Condition segmentsContainsCondition = new Condition();
+
+            segmentsContainsCondition.setConditionType(serviceManager.getDefinitionsService().getConditionType("profileSegmentCondition"));
+            segmentsContainsCondition.setParameter("segments", filterInput.getSegments_contains());
+            segmentsContainsCondition.setParameter("matchType", "in");
 
             conditions.add(segmentsContainsCondition);
         }
@@ -114,8 +118,11 @@ public class CreateOrUpdateSegmentCommand extends BaseCommand<CDPSegment> {
         }
 
         if (filterInput.getLists_contains() != null && !filterInput.getLists_contains().isEmpty()) {
-            final Condition listsContainsCondition =
-                    createContainsCondition(filterInput.getLists_contains(), "profileUserListCondition", "lists");
+            final Condition listsContainsCondition = new Condition();
+
+            listsContainsCondition.setConditionType(serviceManager.getDefinitionsService().getConditionType("profileUserListCondition"));
+            listsContainsCondition.setParameter("lists", filterInput.getLists_contains());
+            listsContainsCondition.setParameter("matchType", "in");
 
             conditions.add(listsContainsCondition);
         }

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/DeleteSegmentCommand.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/commands/segments/DeleteSegmentCommand.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.unomi.graphql.commands.segments;
+
+import com.google.common.base.Strings;
+import org.apache.unomi.api.segments.DependentMetadata;
+import org.apache.unomi.graphql.commands.BaseCommand;
+
+public class DeleteSegmentCommand extends BaseCommand<Boolean> {
+
+    private final String segmentId;
+
+    private DeleteSegmentCommand(Builder builder) {
+        super(builder);
+
+        this.segmentId = builder.segmentId;
+    }
+
+    @Override
+    public Boolean execute() {
+        final DependentMetadata dependentMetadata = serviceManager.getSegmentService().removeSegmentDefinition(segmentId, true);
+
+        return dependentMetadata.getScorings().isEmpty() && dependentMetadata.getSegments().isEmpty();
+    }
+
+    public static Builder create(final String segmentId) {
+        return new Builder(segmentId);
+    }
+
+    public static class Builder extends BaseCommand.Builder<Builder> {
+
+        private final String segmentId;
+
+        public Builder(String segmentId) {
+            this.segmentId = segmentId;
+        }
+
+        private void validate() {
+            if (Strings.isNullOrEmpty(segmentId)) {
+                throw new IllegalArgumentException("The \"segmentID\" variable can not be null or empty");
+            }
+        }
+
+        public DeleteSegmentCommand build() {
+            validate();
+
+            return new DeleteSegmentCommand(this);
+        }
+
+    }
+
+}

--- a/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/CDPMutation.java
+++ b/graphql/cxs-impl/src/main/java/org/apache/unomi/graphql/types/CDPMutation.java
@@ -17,6 +17,7 @@
 package org.apache.unomi.graphql.types;
 
 import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLID;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
 import graphql.schema.DataFetchingEnvironment;
@@ -25,7 +26,8 @@ import org.apache.unomi.graphql.commands.DeleteAllPersonalDataCommand;
 import org.apache.unomi.graphql.commands.DeleteProfileCommand;
 import org.apache.unomi.graphql.commands.DeleteProfilePropertiesCommand;
 import org.apache.unomi.graphql.commands.ProcessEventsCommand;
-import org.apache.unomi.graphql.commands.CreateOrUpdateSegmentCommand;
+import org.apache.unomi.graphql.commands.segments.CreateOrUpdateSegmentCommand;
+import org.apache.unomi.graphql.commands.segments.DeleteSegmentCommand;
 import org.apache.unomi.graphql.types.input.CDPEventInput;
 import org.apache.unomi.graphql.types.input.CDPProfileIDInput;
 import org.apache.unomi.graphql.types.input.CDPPropertyInput;
@@ -99,6 +101,17 @@ public class CDPMutation {
             final DataFetchingEnvironment environment
     ) {
         return CreateOrUpdateSegmentCommand.create(segmentInput, environment)
+                .setServiceManager(environment.getContext())
+                .build()
+                .execute();
+    }
+
+    @GraphQLField
+    public boolean deleteSegment(
+            final @GraphQLID @GraphQLName("segmentID") String segmentId,
+            final DataFetchingEnvironment environment
+    ) {
+        return DeleteSegmentCommand.create(segmentId)
                 .setServiceManager(environment.getContext())
                 .build()
                 .execute();


### PR DESCRIPTION
Implemented the `deleteSegment` mutation

Note: The `Boolean` is used as result type instead of `CDP_Segment`, it was discussed with Serge Huber and @sigdestad  on the last meeting